### PR TITLE
Add embedding helper for SentenceTransformer

### DIFF
--- a/search/embedding.py
+++ b/search/embedding.py
@@ -1,0 +1,8 @@
+from sentence_transformers import SentenceTransformer
+
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+_model = SentenceTransformer(MODEL_NAME)
+
+def embed_text(text: str) -> list[float]:
+    """Return the embedding vector for a single text snippet."""
+    return _model.encode([text])[0].tolist()


### PR DESCRIPTION
## Summary
- add `search/embedding.py` with a helper to embed text using the sentence-transformers model

