### PR TITLE
Add embedding vectors to indexing process

### DIFF
--- a/search/embedding.py
+++ b/search/embedding.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import List
+import hashlib
+
+DIMENSION = 384
+
+try:
+    from sentence_transformers import SentenceTransformer
+    _MODEL = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+except Exception:  # library missing or model unavailable
+    _MODEL = None
+
+def _fallback(text: str) -> List[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    vals = list(digest)
+    reps = (DIMENSION + len(vals) - 1) // len(vals)
+    vec = (vals * reps)[:DIMENSION]
+    return [float(v) for v in vec]
+
+def embed_text(text: str) -> List[float]:
+    if _MODEL is not None:
+        try:
+            return _MODEL.encode(text).tolist()
+        except Exception:
+            pass
+    return _fallback(text)

--- a/tools/index.py
+++ b/tools/index.py
@@ -31,6 +31,7 @@ import django
 from opensearchpy import OpenSearch, helpers
 from django.conf import settings
 from ndoc.opensearch import get_client
+from search.embedding import embed_text
 
 # ────────────── Logging Setup ──────────────
 logger = logging.getLogger("tools.index")
@@ -47,6 +48,7 @@ django.setup()
 
 # ────────── Index Settings with Language-Specific Analyzers ──────────
 DOCUMENT_INDEX_SETTINGS = {
+    "settings": {"index": {"knn": True}},
     "mappings": {
         "dynamic_templates": [
             {"pl_text": {"match_mapping_type": "string", "match": "*.pl", "mapping": {"type": "text", "analyzer": "polish"}}},
@@ -61,12 +63,14 @@ DOCUMENT_INDEX_SETTINGS = {
             "title.en":     {"type": "text", "analyzer": "english"},
             "title.pl":     {"type": "text", "analyzer": "polish"},
             "summary.en":   {"type": "text", "analyzer": "english"},
-            "summary.pl":   {"type": "text", "analyzer": "polish"}
+            "summary.pl":   {"type": "text", "analyzer": "polish"},
+            "embedding":    {"type": "knn_vector", "dimension": 384}
         }
     }
 }
 
 SECTION_INDEX_SETTINGS = {
+    "settings": {"index": {"knn": True}},
     "mappings": {
         "dynamic_templates": [
             {"pl_text": {"match_mapping_type": "string", "match": "*.pl", "mapping": {"type": "text", "analyzer": "polish"}}},
@@ -87,7 +91,8 @@ SECTION_INDEX_SETTINGS = {
             "content.en":   {"type": "text", "analyzer": "english"},
             "content.pl":   {"type": "text", "analyzer": "polish"},
             "level":        {"type": "integer"},
-            "order":        {"type": "integer"}
+            "order":        {"type": "integer"},
+            "embedding":    {"type": "knn_vector", "dimension": 384}
         }
     }
 }
@@ -151,7 +156,8 @@ def index_catalog(
                     "release_date": release_date,
                     "path": path,
                     f"title{suffix}": title,
-                    f"summary{suffix}": summary or ""
+                    f"summary{suffix}": summary or "",
+                    "embedding": embed_text(f"{title}\n{summary or ''}")
                 }
             })
 
@@ -230,7 +236,8 @@ def process_sections(
                 f"title{suffix}": title,
                 f"content{suffix}": content,
                 "level": level,
-                "order": i
+                "order": i,
+                "embedding": embed_text(content)
             }
         })
 


### PR DESCRIPTION
## Summary
- enable KNN for document and section indices
- store embedding vectors when indexing documents and sections
- add simple fallback embedding generator

