### PR TITLE
Add search mode select

### DIFF
--- a/_templates/search.html
+++ b/_templates/search.html
@@ -17,6 +17,10 @@
         <option value="date" {% if sort_by == 'date' %}selected{% endif %}>Release date</option>
         {# removed length since backend doesn’t handle it yet #}
       </select>
+      <select name="mode">
+        <option value="keyword">Keyword</option>
+        <option value="semantic" {% if mode == "semantic" %}selected{% endif %}>Semantic</option>
+      </select>
       <button type="submit">Search</button>
     </form>
   </div>
@@ -35,7 +39,8 @@
       </strong>
       <a href="?q={{ term_suggestion|urlencode }}
                 {% if selected_lang %}&lang={{ selected_lang }}{% endif %}
-                {% if sort_by %}&sort={{ sort_by }}{% endif %}">
+                {% if sort_by %}&sort={{ sort_by }}{% endif %}
+                {% if mode %}&mode={{ mode }}{% endif %}">
         <strong>{{ term_suggestion }}</strong>
       </a>?
     </p>
@@ -55,7 +60,8 @@
       </strong>
       <a href="?q={{ phrase_suggestion|urlencode }}
                 {% if selected_lang %}&lang={{ selected_lang }}{% endif %}
-                {% if sort_by %}&sort={{ sort_by }}{% endif %}">
+                {% if sort_by %}&sort={{ sort_by }}{% endif %}
+                {% if mode %}&mode={{ mode }}{% endif %}">
         <strong>{{ phrase_suggestion|safe }}</strong>
       </a>?
     </p>
@@ -119,7 +125,7 @@
       {% if page > 1 %}
         <a href="?{% if query %}q={{ query|urlencode }}&{% endif %}
                   {% if selected_lang %}lang={{ selected_lang }}&{% endif %}
-                  sort={{ sort_by }}&page={{ page|add:'-1' }}">
+                  sort={{ sort_by }}{% if mode %}&mode={{ mode }}{% endif %}&page={{ page|add:'-1' }}">
           {% if selected_lang == "pl" %}Poprzednia{% else %}Previous{% endif %}
         </a>
       {% endif %}
@@ -127,7 +133,7 @@
       {% if page < total_pages %}
         <a href="?{% if query %}q={{ query|urlencode }}&{% endif %}
                   {% if selected_lang %}lang={{ selected_lang }}&{% endif %}
-                  sort={{ sort_by }}&page={{ page|add:'1' }}">
+                  sort={{ sort_by }}{% if mode %}&mode={{ mode }}{% endif %}&page={{ page|add:'1' }}">
           {% if selected_lang == "pl" %}Następna{% else %}Next{% endif %}
         </a>
       {% endif %}

--- a/search/views.py
+++ b/search/views.py
@@ -344,6 +344,7 @@ def search_documents(request: HttpRequest) -> HttpResponse:
     query = request.GET.get("q", "").strip()
     lang = request.GET.get("lang") or None
     sort_by = request.GET.get("sort", "relevance")
+    mode = request.GET.get("mode", "keyword")
 
     page = 1
     try:
@@ -408,6 +409,7 @@ def search_documents(request: HttpRequest) -> HttpResponse:
         "query": query,
         "selected_lang": lang,
         "sort_by": sort_by,
+        "mode": mode,
         "page": page,
         "total": total,
         "total_pages": total_pages,


### PR DESCRIPTION
## Summary
- add new search mode select element in search form
- persist selected mode by passing it from the view
- include mode parameter in suggestion and pagination links

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840133be8288321943cef575f9a5737