### PR TITLE
Add filter to semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ sequenceDiagram
   - Indexes and retrieves documents efficiently.
   - Supports both **keyword-based** and **vector-based** search.
   - Uses **BM25** (default in OpenSearch) for traditional retrieval and **SentenceTransformer-based embeddings** for semantic matching.
-  - saves recent user search
+  - Users can choose the search mode (keyword vs semantic) via a selector in the UI.
+  - Saves recent user search
 
 - **Frontend (React)**
   - Provides an interactive UI for users to input queries and receive search results.

--- a/search/views.py
+++ b/search/views.py
@@ -345,16 +345,23 @@ def semantic_search(client: OpenSearch, query: str, lang: str | None, is_section
     """Perform a KNN semantic search using vector embeddings."""
     index_name = INDEX_SECTIONS if is_section else INDEX_DOCS
     query_vector = embed_text(query)
-    body: Dict[str, Any] = {
-        "size": MAX_HITS,
-        "query": {
-            "knn": {
-                "embedding": {"vector": query_vector, "k": MAX_HITS}
-            }
-        }
+    knn_query = {
+        "knn": {"embedding": {"vector": query_vector, "k": MAX_HITS}}
     }
+
     if lang in {"pl", "en"}:
-        body["filter"] = [{"term": {"language": lang}}]
+        body = {
+            "size": MAX_HITS,
+            "query": {
+                "bool": {
+                    "must": knn_query,
+                    "filter": [{"term": {"language": lang}}],
+                }
+            },
+        }
+    else:
+        body = {"size": MAX_HITS, "query": knn_query}
+
     return client.search(index=index_name, body=body)
 
 


### PR DESCRIPTION
## Summary
- refine `semantic_search` to apply language filter using `bool`
- note search mode selector in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405c0ed8588321a1dbf919eb3b1f40