### PR TITLE
Add filter to semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,19 @@ sequenceDiagram
   - Indexes and retrieves documents efficiently.
   - Supports both **keyword-based** and **vector-based** search.
   - Uses **BM25** (default in OpenSearch) for traditional retrieval and **SentenceTransformer-based embeddings** for semantic matching.
-  - saves recent user search
+  - Users can choose the search mode (keyword vs semantic) via a selector in the UI.
+  - Before using semantic search, create the indices with embeddings via `python -m tools.index`.
+  - Saves recent user search
+
+> **Note** If you encounter an error stating `Field 'embedding' is not knn_vector type`, re-create the indices with `python -m tools.index` to include the `embedding` vector field.
+
+### Selecting the Search Mode
+Use the dropdown labeled **Mode** on the search page to switch between keyword and semantic search. You can also set `mode=semantic` in the query string, for example:
+
+```
+http://localhost:8000/search/?q=example&mode=semantic
+```
+
 
 - **Frontend (React)**
   - Provides an interactive UI for users to input queries and receive search results.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sentence-transformers>=2.0
+opensearch-py>=2.3

--- a/search/views.py
+++ b/search/views.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from django.shortcuts import render
 from django.http import HttpRequest, HttpResponse
 from opensearchpy import OpenSearch
+from opensearchpy.exceptions import RequestError
 
 from ndoc.opensearch import get_client  # helper
 from .embedding import embed_text
@@ -345,16 +346,23 @@ def semantic_search(client: OpenSearch, query: str, lang: str | None, is_section
     """Perform a KNN semantic search using vector embeddings."""
     index_name = INDEX_SECTIONS if is_section else INDEX_DOCS
     query_vector = embed_text(query)
-    body: Dict[str, Any] = {
-        "size": MAX_HITS,
-        "query": {
-            "knn": {
-                "embedding": {"vector": query_vector, "k": MAX_HITS}
-            }
-        }
+    knn_query = {
+        "knn": {"embedding": {"vector": query_vector, "k": MAX_HITS}}
     }
+
     if lang in {"pl", "en"}:
-        body["filter"] = [{"term": {"language": lang}}]
+        body = {
+            "size": MAX_HITS,
+            "query": {
+                "bool": {
+                    "must": knn_query,
+                    "filter": [{"term": {"language": lang}}],
+                }
+            },
+        }
+    else:
+        body = {"size": MAX_HITS, "query": knn_query}
+
     return client.search(index=index_name, body=body)
 
 
@@ -389,8 +397,13 @@ def search_documents(request: HttpRequest) -> HttpResponse:
     body["size"] = MAX_HITS
 
     if mode == "semantic" and query:
-        resp = semantic_search(client, query, lang, is_section)
-        total = len(resp["hits"]["hits"])
+        try:
+            resp = semantic_search(client, query, lang, is_section)
+            total = len(resp["hits"]["hits"])
+        except RequestError as e:
+            logger.warning("Semantic search failed: %s", e)
+            resp = client.search(index=index_name, body=body)
+            total = resp["hits"]["total"]["value"]
     else:
         resp = client.search(index=index_name, body=body)
         total = resp["hits"]["total"]["value"]


### PR DESCRIPTION
## Summary
- refine `semantic_search` to apply language filter using `bool`
- note search mode selector in README
- add fallback if semantic search raises `RequestError`
- document how to use query parameter `mode`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68405c0ed8588321a1dbf919eb3b1f40