### PR TITLE
Fix KNN settings for semantic search

### DIFF
--- a/tools/index.py
+++ b/tools/index.py
@@ -47,6 +47,9 @@ django.setup()
 
 # ────────── Index Settings with Language-Specific Analyzers ──────────
 DOCUMENT_INDEX_SETTINGS = {
+    "settings": {
+        "index": {"knn": True}
+    },
     "mappings": {
         "dynamic_templates": [
             {"pl_text": {"match_mapping_type": "string", "match": "*.pl",
@@ -71,6 +74,9 @@ DOCUMENT_INDEX_SETTINGS = {
 }
 
 SECTION_INDEX_SETTINGS = {
+    "settings": {
+        "index": {"knn": True}
+    },
     "mappings": {
         "dynamic_templates": [
             {"pl_text": {"match_mapping_type": "string", "match": "*.pl",


### PR DESCRIPTION
## Summary
- enable `knn` option when creating indices in `tools/index.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684297a073908321a22719cf82989eae